### PR TITLE
Use fixed size types in RGB classes.

### DIFF
--- a/RGB.cpp
+++ b/RGB.cpp
@@ -4,24 +4,24 @@ RGB::RGB()
 {
 }
 
-RGB::RGB(int red = 0, int green = 0, int blue = 0)
+RGB::RGB(const uint8_t red = 0, uint8_t green = 0, uint8_t blue = 0)
 {
 	this->redValue = red;
 	this->greenValue = green;
 	this->blueValue = blue;
 }
 
-int RGB::getRed()
+uint8_t RGB::getRed()
 {
 	return this->redValue;
 }
 
-int RGB::getGreen()
+uint8_t RGB::getGreen()
 {
 	return this->greenValue;
 }
 
-int RGB::getBlue()
+uint8_t RGB::getBlue()
 {
 	return this->blueValue;
 }
@@ -47,7 +47,7 @@ RGBA::RGBA(RGB color) : RGB(color)
 	this->alpha = 1;
 }
 
-RGBA::RGBA(int red = 0, int green = 0, int blue = 0, double alpha = 1) : RGB(red, green, blue)
+RGBA::RGBA(const uint8_t red = 0, const uint8_t green = 0, const uint8_t blue = 0, const double alpha = 1) : RGB(red, green, blue)
 {
 	this->alpha = alpha;
 }

--- a/RGB.cpp
+++ b/RGB.cpp
@@ -4,7 +4,7 @@ RGB::RGB()
 {
 }
 
-RGB::RGB(const uint8_t red = 0, uint8_t green = 0, uint8_t blue = 0)
+RGB::RGB(const uint8_t red = 0, const uint8_t green = 0, const uint8_t blue = 0)
 {
 	this->redValue = red;
 	this->greenValue = green;

--- a/RGB.h
+++ b/RGB.h
@@ -1,17 +1,19 @@
 #ifndef RGB_h
 #define RGB_h
 
+#include <stdint.h>
+
 class RGB
 {
 public:
 	RGB();
-	RGB(int red, int green, int blue);
+	RGB(const uint8_t red, uint8_t green, uint8_t blue);
 	bool operator==(const RGB &rhs) const;
 	bool operator!=(const RGB &rhs) const;
 
-	int getRed();
-	int getGreen();
-	int getBlue();
+	uint8_t getRed();
+	uint8_t getGreen();
+	uint8_t getBlue();
 
 	static RGB white;
 	static RGB red;
@@ -23,16 +25,16 @@ public:
 	static RGB black;
 
 protected:
-	int redValue;
-	int greenValue;
-	int blueValue;
+	uint8_t redValue;
+	uint8_t greenValue;
+	uint8_t blueValue;
 };
 
 class RGBA : public RGB
 {
 public:
 	RGBA(RGB color);
-	RGBA(int red, int green, int blue, double alpha);
+	RGBA(const uint8_t red, const uint8_t green, const uint8_t blue, const double alpha);
 	RGB toRGB(void);
 
 private:

--- a/RGB.h
+++ b/RGB.h
@@ -7,7 +7,7 @@ class RGB
 {
 public:
 	RGB();
-	RGB(const uint8_t red, uint8_t green, uint8_t blue);
+	RGB(const uint8_t red, const uint8_t green, const uint8_t blue);
 	bool operator==(const RGB &rhs) const;
 	bool operator!=(const RGB &rhs) const;
 

--- a/RgbLed.cpp
+++ b/RgbLed.cpp
@@ -1,6 +1,6 @@
 #include "RgbLed.h"
 
-int RgbLed::channel = 3; // Channel must be in range of 0-16
+uint8_t RgbLed::channel = 3; // Channel must be in range of 0-16
 
 void RgbLed::driveLeds(RGB color)
 {
@@ -20,7 +20,7 @@ void RgbLed::driveLeds(RGB color)
 	}
 }
 
-RgbLed::RgbLed(int redPin, int greenPin, int bluePin)
+RgbLed::RgbLed(const uint8_t redPin, const uint8_t greenPin, const uint8_t bluePin)
 {
 	this->redPin = redPin;
 	this->greenPin = greenPin;
@@ -30,7 +30,7 @@ RgbLed::RgbLed(int redPin, int greenPin, int bluePin)
 	{
 		this->redChannel = RgbLed::newChannel();
 		pinMode(this->redPin, OUTPUT);
-		ledcAttachPin(redPin, this->redChannel); // assign led pin to channel
+		ledcAttachPin(this->redPin, this->redChannel); // assign led pin to channel
 		ledcSetup(this->redChannel, 12000, 8);	 // 12 kHz PWM, 8-bit resolution
 	}
 
@@ -38,7 +38,7 @@ RgbLed::RgbLed(int redPin, int greenPin, int bluePin)
 	{
 		this->greenChannel = RgbLed::newChannel();
 		pinMode(this->greenPin, OUTPUT);
-		ledcAttachPin(greenPin, this->greenChannel);
+		ledcAttachPin(this->greenPin, this->greenChannel);
 		ledcSetup(this->greenChannel, 12000, 8);
 	}
 
@@ -46,12 +46,12 @@ RgbLed::RgbLed(int redPin, int greenPin, int bluePin)
 	{
 		this->blueChannel = RgbLed::newChannel();
 		pinMode(this->bluePin, OUTPUT);
-		ledcAttachPin(bluePin, this->blueChannel);
+		ledcAttachPin(this->bluePin, this->blueChannel);
 		ledcSetup(this->blueChannel, 12000, 8);
 	}
 }
 
-int RgbLed::newChannel()
+uint8_t RgbLed::newChannel()
 {
 	RgbLed::channel++;
 	return RgbLed::channel;

--- a/RgbLed.h
+++ b/RgbLed.h
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include <stdint.h>
 #include "RGB.h"
 
 #ifndef RgbLed_h
@@ -7,23 +8,23 @@
 class RgbLed
 {
 private:
-	int redPin;
-	int greenPin;
-	int bluePin;
+	uint8_t redPin;
+	uint8_t greenPin;
+	uint8_t bluePin;
 	
-	int redChannel;
-	int greenChannel;
-	int blueChannel;
+	uint8_t redChannel;
+	uint8_t greenChannel;
+	uint8_t blueChannel;
 	RGB color;
 	bool active = true;
 
-	static int channel;
-	static int newChannel();
+	static uint8_t channel;
+	static uint8_t newChannel();
 
 	void driveLeds(RGB color);
 
 public:
-	RgbLed(int redPin, int greenPin, int bluePin);
+	RgbLed(const uint8_t redPin, const uint8_t greenPin, const uint8_t bluePin);
 
 	void setColor(RGBA color);
 	void setColor(RGB color);


### PR DESCRIPTION
To reduce memory usage and avoid portability to other devices/systems problems, a fixed size types must be used.

An "int" is a 32 bits variable in ESP32, but if you use some of this code in Arduino UNO (atmega328 microcontroller), the "int" is 16 bits, so it could be an issue if you expect that some of the variables stores a value greater than 2¹⁶ when you use the code in another device... Also, if you know that a variable value never going to be higher than 255 (2⁸), then why waste static memory using an int that is a 32 bits instead just 8 bits? Memory is the most valuable resource in embedded world for constrained devices ;)

To avoid all this problems, it is a must to use fixed size types like "uint8", "uint16_t", "uint32_t", "int8_t", "int16_t", "int32_t", etc. instead unknown size types like int.

Here a fix in RGB classes pins, channels and color values to use uint8_t, because we know that neither pins, values or channels never doesn't need to go with a value higher than 255.

Best regards.