### PR TITLE
Place includes after guards.

### DIFF
--- a/HapticFeedback.h
+++ b/HapticFeedback.h
@@ -1,8 +1,9 @@
-#include <Arduino.h>
-#include <vector>
 
 #ifndef HapticFeedback_h
 #define HapticFeedback_h
+
+#include <Arduino.h>
+#include <vector>
 
 enum InstructionTypes
 {

--- a/MqttCallback.h
+++ b/MqttCallback.h
@@ -1,7 +1,8 @@
-#include "Arduino.h"
 
 #ifndef MqttCallback_h
 #define MqttCallback_h
+
+#include "Arduino.h"
 
 class MqttCallback
 {

--- a/MqttConnection.h
+++ b/MqttConnection.h
@@ -1,10 +1,10 @@
 
+#ifndef MqttConnection_h
+#define MqttConnection_h
+
 #include <ESP.h>
 #include "WiFiConnection.h"
 #include "PubSubClient.h"
-
-#ifndef MqttConnection_h
-#define MqttConnection_h
 
 class MqttConnection
 {

--- a/Observable.h
+++ b/Observable.h
@@ -1,8 +1,9 @@
-#include <iostream>
-#include <vector>
 
 #ifndef Observable_h
 #define Observable_h
+
+#include <iostream>
+#include <vector>
 
 class Subject; 
 

--- a/PubSubClient.cpp
+++ b/PubSubClient.cpp
@@ -6,7 +6,6 @@
 */
 
 #include "PubSubClient.h"
-#include "Arduino.h"
 
 PubSubClient::PubSubClient()
 {

--- a/RgbLed.h
+++ b/RgbLed.h
@@ -1,8 +1,10 @@
-#include <Arduino.h>
-#include "RGB.h"
 
 #ifndef RgbLed_h
 #define RgbLed_h
+
+#include <Arduino.h>
+#include <stdint.h>
+#include "RGB.h"
 
 class RgbLed
 {

--- a/Wallswitch.h
+++ b/Wallswitch.h
@@ -1,3 +1,7 @@
+
+#ifndef WALLSWITCH_h
+#define WALLSWITCH_h
+
 #include "OneButton.h"
 #include "HapticFeedback.h"
 #include "RgbLed.h"
@@ -20,3 +24,5 @@ public:
     void setHaptic(HapticFeedback *haptic);
     void setLed(RgbLed *led);
 };
+
+#endif /* WALLSWITCH_h */

--- a/WallswitchWiFiObserver.h
+++ b/WallswitchWiFiObserver.h
@@ -1,3 +1,7 @@
+
+#ifndef WALLSWITCHWIFIOBSERVER_h
+#define WALLSWITCHWIFIOBSERVER_h
+
 #include "Observable.h"
 #include "WiFiConnection.h"
 #include "RgbLed.h"
@@ -54,3 +58,5 @@ void WallswitchWiFiObserver::Update(Subject &subject)
         }
     }
 }
+
+#endif /* WALLSWITCHWIFIOBSERVER_h */

--- a/WiFiConnection.h
+++ b/WiFiConnection.h
@@ -1,8 +1,9 @@
-#include <WiFi.h>
-#include "Observable.h"
 
 #ifndef WiFiConnection_h
 #define WiFiConnection_h
+
+#include <WiFi.h>
+#include "Observable.h"
 
 class WiFiConnection : public Subject
 {


### PR DESCRIPTION
To avoid possible circular library inclusions and speed-up compilation time, libraries includes must be placed after headers guards.

Also, added some missing header guard in "WallswitchWiFiObserver.h" and "Wallswitch.h" files.

Regards.